### PR TITLE
Add back in call to `addDrupalExtensions`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,8 @@ const plugin = (options = {}) => {
 
         ${functions}
 
+        addDrupalExtensions(Twig);
+        
         // Disable caching.
         Twig.cache(false);
 

--- a/tests/__snapshots__/smoke.test.js.snap
+++ b/tests/__snapshots__/smoke.test.js.snap
@@ -1,5 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Basic smoke test > Should recognise default Drupal functions 1`] = `
+"
+<p>Functions work</p>"
+`;
+
 exports[`Basic smoke test > Should support global context and functions 1`] = `
 "<section>
   <h1>Include</h1>

--- a/tests/fixtures/drupal-functions.twig
+++ b/tests/fixtures/drupal-functions.twig
@@ -1,0 +1,2 @@
+{{ attach_library('drupal/library') }}
+<p>Functions work</p>

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,6 +1,7 @@
 import Markup from "../dist/test.js"
 import Error from "../dist/error.js"
 import ErrorInclude from "../dist/errorInclude.js"
+import drupalFunctions from "../dist/drupalFunctions.js"
 import Menu from "../dist/menu.js"
 import { describe, expect, it } from "vitest"
 
@@ -34,5 +35,10 @@ describe("Basic smoke test", () => {
     expect(markup).toMatchSnapshot()
     expect(markup).toContain("Nested include")
     expect(markup).toContain("IT WORKS!")
+  })
+  it("Should recognise default Drupal functions", () => {
+    const markup = drupalFunctions()
+    expect(markup).toMatchSnapshot()
+    expect(markup).toContain("Functions work")
   })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
         error: resolve(__dirname, "tests/fixtures/error.twig"),
         menu: resolve(__dirname, "tests/fixtures/menu.twig"),
         errorInclude: resolve(__dirname, "tests/fixtures/error-include.twig"),
+        drupalFunctions: resolve(
+          __dirname,
+          "tests/fixtures/drupal-functions.twig"
+        ),
       },
       name: "vite-plugin-twig-drupal",
       fileName: (_, entry) => `${entry}.js`,


### PR DESCRIPTION
In https://github.com/larowlan/vite-plugin-twig-drupal/pull/10, the ability was added to pass functions in. I think I advertantly took the  `addDrupalExtensions(Twig);` line out, which then fails when using Drupal functions like `attach_library()`.

It was in there before, and re-instating it solves the problem :) 